### PR TITLE
[suggestion] Change element location method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+geckodriver.log

--- a/chr.py
+++ b/chr.py
@@ -4,19 +4,16 @@ from selenium.webdriver.common.keys import Keys
 driver = webdriver.Firefox()
 driver.get("http://www.facebook.com")
 assert "Facebook" in driver.title
-elem = driver.find_element_by_name("email")
+elem = driver.find_element_by_id("email")
 elem.clear()
-elem.send_keys("8768884446")
-elem.send_keys(Keys.RETURN)
+elem.send_keys("bdaybottest@gmail.com")
 
-elem = driver.find_element_by_name("pass")
+elem = driver.find_element_by_id("pass")
 elem.clear()
-elem.send_keys("")
-elem.send_keys(Keys.RETURN)
-elem.clear()
+elem.send_keys("12345679")
 
-elem=driver.find_element_by_class_name('_s0 _7ql _ry img')
-elem.click()
+elem=driver.find_element_by_id('u_0_l')
+elem.send_keys(Keys.RETURN)
 
 assert "No results found." not in driver.page_source
 driver.close()


### PR DESCRIPTION
Changed the element location strategy from _find_element_by_name_ to *_find_element_by_id_*.

`driver.find_element_by_class_name('_s0 _7ql _ry img')` was giving errors.